### PR TITLE
use absolute path with ReportUnit()

### DIFF
--- a/build/scripts/test.cake
+++ b/build/scripts/test.cake
@@ -60,7 +60,8 @@ Task("Run-Unit-Tests")
 
     if (testNames.Count > 0)
     {
-        ReportUnit(testResultsDir);
+        string reportPath = System.IO.Path.GetFullPath(testResultsDir);
+        ReportUnit(reportPath);
     }
 })
 .OnError(exception =>


### PR DESCRIPTION
As defined in variables.cake, testResultsDir is a relative path
var buildResultDir = "./build/results";
var testResultsDir = buildResultDir + "/tests";

ReportUnit() takes absolute paths.
https://github.com/reportunit/reportunit/issues/34